### PR TITLE
Fix O(N^2 log N) merge sort implementations (Python/JS/C++)

### DIFF
--- a/src/code/cpp/sorting_algorithms/merge_sort.cpp
+++ b/src/code/cpp/sorting_algorithms/merge_sort.cpp
@@ -5,20 +5,21 @@ using namespace std;
 
 vector<int> Merge(vector<int>& left, vector<int>& right) {
     vector<int> output;
+    size_t i = 0;
+    size_t j = 0;
 
-    while (!left.empty() && !right.empty()) {
-        int min_num = (left[0] <= right[0]) ? left[0] : right[0];
-        output.push_back(min_num);
-
-        if (left[0] <= right[0]) {
-            left.erase(left.begin());
+    while (i < left.size() && j < right.size()) {
+        if (left[i] <= right[j]) {
+            output.push_back(left[i]);
+            i++;
         } else {
-            right.erase(right.begin());
+            output.push_back(right[j]);
+            j++;
         }
     }
 
-    output.insert(output.end(), left.begin(), left.end());
-    output.insert(output.end(), right.begin(), right.end());
+    output.insert(output.end(), left.begin() + i, left.end());
+    output.insert(output.end(), right.begin() + j, right.end());
 
     return output;
 }

--- a/src/code/javascript/sorting_algorithms/merge_sort.js
+++ b/src/code/javascript/sorting_algorithms/merge_sort.js
@@ -14,14 +14,21 @@ const mergeSort = (arr) => {
 
 const merge = (left, right) => {
     const output = []
+    let i = 0
+    let j = 0
 
-    while (left.length && right.length) {
-        const minNum = left[0] <= right[0] ? left.shift() : right.shift()
-        output.push(minNum)
+    while (i < left.length && j < right.length) {
+        if (left[i] <= right[j]) {
+            output.push(left[i])
+            i += 1
+        } else {
+            output.push(right[j])
+            j += 1
+        }
     }
 
-    output.push(...left)
-    output.push(...right)
+    output.push(...left.slice(i))
+    output.push(...right.slice(j))
 
     return output
 }

--- a/src/code/python/sorting_algorithms/merge_sort.py
+++ b/src/code/python/sorting_algorithms/merge_sort.py
@@ -12,12 +12,17 @@ def merge_sort(arr: list) -> list:
 
 def merge(left: list, right: list) -> list:
     output = []
+    i = j = 0
 
-    while left and right:
-        min_num = left.pop(0) if left[0] <= right[0] else right.pop(0)
-        output.append(min_num)
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            output.append(left[i])
+            i += 1
+        else:
+            output.append(right[j])
+            j += 1
 
-    output.extend(left)
-    output.extend(right)
+    output.extend(left[i:])
+    output.extend(right[j:])
 
     return output


### PR DESCRIPTION
The merge step is O(N^2), leading to an overall time complexity of O(N^2 logN) in the Python, JavaScript, and C++ implementations.

```python
def merge(left: list, right: list) -> list:
    output = []

    while left and right:
        min_num = left.pop(0) if left[0] <= right[0] else right.pop(0) # O(N) -- pop(0) shifts every remaining element
        output.append(min_num)

    output.extend(left)
    output.extend(right)

    return output
```

But merge sort should be O(N log N). The fix is to stop removing from the front of the list, and instead walk both halves with index pointers.


```python
def merge(left: list, right: list) -> list:
    output = []
    i = j = 0

    while i < len(left) and j < len(right):
        if left[i] <= right[j]:
            output.append(left[i])
            i += 1
        else:
            output.append(right[j])
            j += 1

    output.extend(left[i:])
    output.extend(right[j:])

    return output
```

This brings the merge back to O(N), and the overall sort to O(N log N). 

I applied the same fix to the JavaScript and C++ implementations. Java and Lua already use index pointers. Finally, Ruby's `shift` is an O(1) amortized operation (internally, it moves a pointer instead of shifting elements).